### PR TITLE
add boilerplate to make that easier to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dpkg-memstats

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+# assumes your GOPATH is set, which is default in 1.8 and later
+
+dpkg-memstats: dpkg-memstats.go packagemap.go
+	go build $^
+
+go-humanize:
+	go get github.com/dustin/go-humanize
+
+clean:
+	rm dpkg-memstats

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# dpkg-memstats
+
+This tool shows memory usage per Debian package. It is not part of
+dpkg.
+
+To build, simply run `make` if you have that installed, otherwise `go
+build *.go` should get you started. This requires the
+[dustin/go-humanize](https://github.com/dustin/go-humanize) library.
+
+Make sure your `GOPATH` environment is correctly set (to `~/go` in
+Golang 1.8 or later).


### PR DESCRIPTION
had to figure that out, which may seem trivial for long time golang-ers, but i'm new and others might be as well. :)

this is partly to see if i figured this out correctly... is there no way to import `go-humanize` more generically? what if you need to make changes to that library or one of its dependencies?

after reading [this article regarding Python](https://caremad.io/posts/2013/07/setup-vs-requirement/), i wonder if there's a way to make those imports more generic in Go...

thanks for sharing the code!!